### PR TITLE
Fixed node names using relative path + filename on macOs.

### DIFF
--- a/index.js
+++ b/index.js
@@ -60,7 +60,7 @@ module.exports = function (fileName, converter) {
         })
       }
 
-      data[file.relative.substr(0,file.relative.length-5)] = JSON.parse(file.contents.toString());
+      data[path.basename(file.relative, ".json")] = JSON.parse(file.contents.toString());
 
     } catch (err) {
       skipConversion = true;


### PR DESCRIPTION
I ran into an issue with the node names containing part of the file path, only on macOs. Might be an issue on Linux too.

Colleague is using Windows and it's working fine for her. Shes tested the fix there and its still working as expected, I've tested on macOS and can confirm that its now working as expected too.